### PR TITLE
Fixing widget CSS/JS imports for Django 1.8

### DIFF
--- a/paintstore/widgets.py
+++ b/paintstore/widgets.py
@@ -6,12 +6,12 @@ from django.utils.safestring import mark_safe
 class ColorPickerWidget(forms.TextInput):
     class Media:
         css = {
-            "all": ("%s/%s" % (settings.STATIC_URL, "paintstore/css/colorpicker.css"),)
+            "all": ("%s%s" % (settings.STATIC_URL, "paintstore/css/colorpicker.css"),)
         }
 
         js  = (
-            ("%s/%s" % (settings.STATIC_URL, "paintstore/jquery_1.7.2.js")),
-            ("%s/%s" % (settings.STATIC_URL, "paintstore/colorpicker.js"))
+            ("%s%s" % (settings.STATIC_URL, "paintstore/jquery_1.7.2.js")),
+            ("%s%s" % (settings.STATIC_URL, "paintstore/colorpicker.js"))
         )
 
     input_type = 'colorpicker'


### PR DESCRIPTION
In Django 1.8, trailing slashes on `STATIC_URL` are enforced, so the import URL for the CSS and JS doesn't need to add it. In fact, with it, I get breakage on the admin page, with a bunch of errors of the form:

```
GET http://127.0.0.1:8000/static//paintstore/jquery_1.7.2.js 
```

for each static resource paintstore requires.

This fixes it, at least on Django 1.8.
